### PR TITLE
Added main section to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "raleway-fonts",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "homepage": "https://github.com/williamcanin/raleway-fonts",
   "authors": [
     "William Canin <william.costa.canin@gmail.com>"
@@ -20,6 +20,21 @@
     "webfonts",
     "web",
     "fonts"
+  ],
+  "main": [
+	"./css/raleway.css",
+	"./css/raleway.min.css",
+	"./less/raleway.less",
+	"./scss/_raleway.scss",
+	"./fonts/fonts-raleway/Raleway-Bold.ttf",
+	"./fonts/fonts-raleway/Raleway-ExtraBold.ttf",
+	"./fonts/fonts-raleway/Raleway-ExtraLight.ttf",
+	"./fonts/fonts-raleway/Raleway-Heavy.ttf",
+	"./fonts/fonts-raleway/Raleway-Light.ttf",
+	"./fonts/fonts-raleway/Raleway-Medium.ttf",
+	"./fonts/fonts-raleway/Raleway-Regular.ttf",
+	"./fonts/fonts-raleway/Raleway-SemiBold.ttf",
+	"./fonts/fonts-raleway/Raleway-Thin.ttf"
   ],
   "licenses": [
     {


### PR DESCRIPTION
I had an issue using the Gulp.js plugin main-bower-files. This plugin looks for a "main" section in bower.json of bower packages to take specific files. Because no main section existed, the Gruntfile.js in your package got copied instead (and later also loaded in the browser by the gulp-inject plugin).
This throws an error of course because I'm not using Grunt.

I already increased the version number in bower.json for you as well.